### PR TITLE
Add status not to retry #1168763358571705

### DIFF
--- a/src/ApiBuilder.php
+++ b/src/ApiBuilder.php
@@ -352,7 +352,9 @@ class ApiBuilder
                 $object->meta->tries = $tries;
 
                 // Check if we should retry
-                $statusesNotToRetry = [400, 401, 404, 406, 422];
+                $configStatus = array_get($config,'status_not_to_retry',[]);
+                $defaultStatus = [400, 401, 404, 406, 422];
+                $statusesNotToRetry = array_merge($configStatus, $defaultStatus);
 
                 if (in_array($httpStatusCode, $statusesNotToRetry)) {
                     Log::debug('ApiBuilder->call() - Call failed but status is in blacklist. Not retrying.', [

--- a/src/Config/api_helper.php
+++ b/src/Config/api_helper.php
@@ -78,6 +78,9 @@ return [
             // number of retries to override global settings.
             'number_of_retries' => 0, // 0 = off
 
+            //status not to retry, define status code for which api will not retried
+            'status_not_to_retry' => [517],
+
             // List of API routes we are integrating with
             'routes' => [
 


### PR DESCRIPTION
**Status Not To Retry**
- Add option that you can define status array inside your api config, so that can be added as blacklist for not retrieving.
```php
'connections' => [

        // HTTPBin
        'httpbin' => [ //Your api array
            'root' => '',

            //Set method name for custom escape characters
            'character_escape_method' => '',

            // API type: json or xml or view
            'type' => 'json',

            // API base URL
            'base_url' => 'https://httpbin.org',

            // Default Request options. these are included with all calls unless overwritten
            'default_request_options' => [
                'http_errors' => true,
                'connect_timeout' => 10,
                'timeout' => 30,
                'headers' => [
                    "Accept" => "application/json",
                    "Content-Type" => "application/json",
                ],
            ],

            // number of retries to override global settings.
            'number_of_retries' => 0, // 0 = off

            //status not to retry, define status code for which api will not retried
            'status_not_to_retry' => [517],
```