### PR TITLE
Function call back support#1168097120836859

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.1.22
+- This version include support of call back function for prometheus config.
+
 ## 0.1.21
 - Add support for metrics, which will use app prometheus to export metrics.
 

--- a/src/Helpers/StatsHelper.php
+++ b/src/Helpers/StatsHelper.php
@@ -29,7 +29,17 @@ class StatsHelper
             if (!empty($prometheusConfigLables) && is_array($prometheusConfigLables) === true) {
                 foreach ($prometheusConfigLables as $key => $row) {
                     $labelNames[] = $key;
-                    $labels[] = $row;
+                    if (stripos($row, '@') !== false) {
+                        // we have an @ - callable
+                        $callable = explode('@', $row);
+                        if (is_callable($callable)) {
+                            $labels[] = call_user_func($callable);
+                        } else {
+                            $labels[] = $row;
+                        }
+                    } else {
+                        $labels[] = $row;
+                    }
                 }
             }
 


### PR DESCRIPTION
- In previous version we have added prometheus, So in this we are adding call back support for prometheus config.

- So developer can retrieve dynamic values and assign in config use below example.

```php
prometheus' => [
        'labels' => [
            'client_id' => 'App\Helpers\SomeHelper@returnClientId',
        ],
```

here method name is after `@` and you have to specify `namespace + class` before it.